### PR TITLE
Fixed bug where enemy health is saved as 0

### DIFF
--- a/Yuna/Assets/Prefabs/Enemy.prefab
+++ b/Yuna/Assets/Prefabs/Enemy.prefab
@@ -1990,7 +1990,7 @@ MonoBehaviour:
   kanzashiCriticalDamage: 100
   tessenDamage: 999
   criticalColliders:
-  - {fileID: 0}
+  - {fileID: 5070061292031352357}
 --- !u!114 &5790966587338871961
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Yuna/Assets/Scripts/Enemy/EnemyHealth.cs
+++ b/Yuna/Assets/Scripts/Enemy/EnemyHealth.cs
@@ -6,10 +6,10 @@ public class EnemyHealth : MonoBehaviour
 {
     [Header("Health Settings")]
     [field: SerializeField] public int MaxHealth { get; private set; } = 100;
-    public int CurrentHealth { get; private set; }
+    public int? CurrentHealth { get; private set; }
 
     public event Action OnDeath;
-    public bool IsDead => CurrentHealth <= 0;
+    public bool IsDead => CurrentHealth.GetValueOrDefault(MaxHealth) <= 0;
 
     [Header("Damage Settings")]
     [SerializeField] private int kanzashiDamage = 25;
@@ -28,7 +28,7 @@ public class EnemyHealth : MonoBehaviour
 
 
     public void ResetHealth() => CurrentHealth = MaxHealth;
-    public void SaveHealth() => MaxHealth = CurrentHealth;
+    public void SaveHealth() => MaxHealth = CurrentHealth.GetValueOrDefault(MaxHealth);
 
 
     public void Kill()


### PR DESCRIPTION
[Fixed bug where enemy health is saved as 0](https://github.com/sonic28g/Yuna/commit/eef81255b8f6dee7cbf7d6c81abea18a42493138)
- Added missing criticalCollider on enemy prefab.